### PR TITLE
Fix PHPDocs.

### DIFF
--- a/DalStatement.php
+++ b/DalStatement.php
@@ -168,7 +168,7 @@ class DalStatement {
      * there is no more row.
      *
      * @access  public
-     * @param   string  $column    Column index.
+     * @param   int  $column    Column index.
      * @return  mixed
      * @throw   \Hoa\Database\Exception
      */

--- a/IDal/WrapperStatement.php
+++ b/IDal/WrapperStatement.php
@@ -55,7 +55,7 @@ interface WrapperStatement {
      * @access  public
      * @param   array   $bindParameters    Bind parameters values if
      *                                     bindParameter() is not called.
-     * @return  bool
+     * @return  \Hoa\Database\IDal\WrapperStatement
      * @throw   \Hoa\Database\Exception
      */
     public function execute ( Array $bindParameters = array() );
@@ -88,7 +88,7 @@ interface WrapperStatement {
      * there is no more row.
      *
      * @access  public
-     * @param   string  $column    Column index.
+     * @param   int  $column    Column index.
      * @return  mixed
      * @throw   \Hoa\Database\Exception
      */

--- a/Layer/Pdo/Statement.php
+++ b/Layer/Pdo/Statement.php
@@ -172,7 +172,7 @@ class Statement implements \Hoa\Database\IDal\WrapperStatement {
      * there is no more row.
      *
      * @access  public
-     * @param   string  $column    Column index.
+     * @param   int  $column    Column index.
      * @return  mixed
      * @throw   \Hoa\Database\Exception
      */


### PR DESCRIPTION
Return tag of `Hoa\Database\IDal\WrapperStatement::execute()` should be `Hoa\Database\IDal\WrapperStatement` because `Hoa\Database\DalStatement` and `Hoa\Database\Layer\Pdo\Statement` return `$this` and not a boolean like the native method `execute`.

And `*Statement::fetchColumn()`'s parameter to `int` like on [php.net (PDOStatement)](http://php.net/manual/en/pdostatement.fetchcolumn.php). Moreover `string $column = 0` isn't good ;)
