### PR TITLE
Correct composer dependencies about pdo

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     },
     "require": {
         "hoa/core": "dev-master",
-        "ext/pdo" : "*"
+        "ext-pdo" : "*"
     },
     "minimum-stability": "dev",
     "target-dir"       : "Hoa/Database",


### PR DESCRIPTION
I tried to take hoa/database throught composer.
And like you can see here: https://packagist.org/packages/hoa/database, 0 download of this package since all time, so i said "something i wrong !"

And i found the problem after some search, the pdo dependencies in the composer.json isn't good.
(You put ext/pdo but ext-pdo is needed here, more information here: https://getcomposer.org/doc/02-libraries.md#platform-packages)
