### PR TITLE
Introduce Enclose names feature.

### DIFF
--- a/Query/Delete.php
+++ b/Query/Delete.php
@@ -46,6 +46,8 @@ namespace Hoa\Database\Query;
  */
 class Delete extends Where implements Dml
 {
+    use EncloseIdentifier;
+
     /**
      * Table name.
      *
@@ -75,6 +77,9 @@ class Delete extends Where implements Dml
      */
     public function __toString()
     {
-        return 'DELETE FROM ' . $this->_from . parent::__toString();
+        return
+            'DELETE FROM ' .
+            $this->enclose($this->_from) .
+            parent::__toString();
     }
 }

--- a/Query/EncloseIdentifier.php
+++ b/Query/EncloseIdentifier.php
@@ -37,36 +37,106 @@
 namespace Hoa\Database\Query;
 
 /**
- * Interface \Hoa\Database\Query\Dml.
+ * Trait \Hoa\Database\Query\EncloseIdentifier.
  *
- * Represent Data Manipulation Language queries.
+ * Enclose identifier feature.
  *
  * @copyright  Copyright © 2007-2015 Hoa community
  * @license    New BSD License
  */
-interface Dml
+trait EncloseIdentifier
 {
+    /**
+     * State of the enclosing: Either true for enable the enclosing feature
+     * or false for disable it.
+     *
+     * @var bool
+     */
+    protected $_enableEnclose = false;
+
+    /**
+     * Enclose opening symbol.
+     *
+     * @var string
+     */
+    protected $_openingSymbol = '"';
+
+    /**
+     * Enclose closing symbol.
+     *
+     * @var string
+     */
+    protected $_closingSymbol = '"';
+
+
+
     /**
      * Set enclose symbols.
      *
      * @param   string  $openingSymbol    Opening symbol.
      * @param   string  $closingSymbol    Closing symbol.
-     * @return  \Hoa\Database\Query\Dml
+     * @return  \Hoa\Database\Query\EncloseNames
      */
-    public function setEncloseSymbol($openingSymbol, $closingSymbol = null);
+    public function setEncloseSymbol($openingSymbol, $closingSymbol = null)
+    {
+        $this->_openingSymbol = $openingSymbol;
+        $this->_closingSymbol =
+            (null === $closingSymbol)
+                ? $openingSymbol
+                : $closingSymbol;
+
+        return $this;
+    }
 
     /**
      * Enable or disable enclosing identifiers.
      *
      * @param   bool  $enable    Enable or disable.
-     * @return  \Hoa\Database\Query\Dml
+     * @return  bool
      */
-    public function enableEncloseIdentifier($enable = true);
+    public function enableEncloseIdentifier($enable = true)
+    {
+        $old                  = $this->_enableEnclose;
+        $this->_enableEnclose = $enable;
+
+        return $old;
+    }
 
     /**
-     * Generate the query.
+     * Enclose identifiers with defined symbol.
      *
+     * @param   array|string  $identifiers    Table/column/alias identifiers.
+     * @return  array|string
+     */
+    protected function enclose($identifiers)
+    {
+        if (false === $this->_enableEnclose) {
+            return $identifiers;
+        }
+
+        if (false === is_array($identifiers)) {
+            return $this->_enclose($identifiers);
+        }
+
+        foreach ($identifiers as &$identifier) {
+            $identifier = $this->_enclose($identifier);
+        }
+
+        return $identifiers;
+    }
+
+    /**
+     * Enclose identifier with defined symbol.
+     *
+     * @param   string  $identifier    Identifier.
      * @return  string
      */
-    public function __toString();
+    protected function _enclose($identifier)
+    {
+        if (0 === preg_match('#\s|\(#', $identifier)) {
+            return $this->_openingSymbol . $identifier . $this->_closingSymbol;
+        }
+
+        return $identifier;
+    }
 }

--- a/Query/Insert.php
+++ b/Query/Insert.php
@@ -46,6 +46,8 @@ namespace Hoa\Database\Query;
  */
 class Insert implements Dml
 {
+    use EncloseIdentifier;
+
     /**
      * Source.
      *
@@ -245,14 +247,14 @@ class Insert implements Dml
             $out .= ' OR ' . $this->_or;
         }
 
-        $out .= ' INTO ' . $this->_into;
+        $out .= ' INTO ' . $this->enclose($this->_into);
 
         if (true === $this->_defaultValues) {
             return $out . ' DEFAULT VALUES';
         }
 
         if (!empty($this->_columns)) {
-            $out .= ' (' . implode(', ', $this->_columns) . ')';
+            $out .= ' (' . implode(', ', $this->enclose($this->_columns)) . ')';
         }
 
         if (is_string($this->_values)) {

--- a/Query/Select.php
+++ b/Query/Select.php
@@ -192,7 +192,9 @@ class Select extends SelectCore implements Dml
         $out .= parent::__toString();
 
         if (!empty($this->_orderBy)) {
-            $out .= ' ORDER BY ' . implode(', ', $this->_orderBy);
+            $out .=
+                ' ORDER BY ' .
+                implode(', ', $this->enclose($this->_orderBy));
         }
 
         if (!empty($this->_limit)) {

--- a/Query/SelectCore.php
+++ b/Query/SelectCore.php
@@ -46,6 +46,8 @@ namespace Hoa\Database\Query;
  */
 abstract class SelectCore extends Where
 {
+    use EncloseIdentifier;
+
     /**
      * Columns.
      *
@@ -332,7 +334,10 @@ abstract class SelectCore extends Where
         end($this->_from);
         $key               = key($this->_from);
         $value             = current($this->_from);
-        $this->_from[$key] = $value . ' ' . $type . ' ' . $source;
+        $this->_from[$key] =
+            $this->enclose($value) .' ' .
+            $type . ' ' .
+            $this->enclose($source);
 
         return new Join($this, $this->_from);
     }
@@ -368,7 +373,7 @@ abstract class SelectCore extends Where
         }
 
         if (!empty($this->_columns)) {
-            $out .= ' ' . implode(', ', $this->_columns);
+            $out .= ' ' . implode(', ', $this->enclose($this->_columns));
         } else {
             $out .= ' *';
         }
@@ -379,9 +384,11 @@ abstract class SelectCore extends Where
 
             foreach ($this->_from as $alias => $from) {
                 if (is_int($alias)) {
-                    $handle[] = $from;
+                    $handle[] = $this->enclose($from);
                 } else {
-                    $handle[] = $from . ' AS ' . $alias;
+                    $handle[] =
+                        $this->enclose($from) .
+                        ' AS ' . $this->enclose($alias);
                 }
             }
 
@@ -391,7 +398,9 @@ abstract class SelectCore extends Where
         $out .= parent::__toString();
 
         if (!empty($this->_groupBy)) {
-            $out .= ' GROUP BY ' . implode(', ', $this->_groupBy);
+            $out .=
+                ' GROUP BY ' .
+                implode(', ', $this->enclose($this->_groupBy));
 
             if (!empty($this->_having)) {
                 $out .= ' HAVING ' . $this->_having;

--- a/Query/Update.php
+++ b/Query/Update.php
@@ -46,6 +46,8 @@ namespace Hoa\Database\Query;
  */
 class Update extends Where implements Dml
 {
+    use EncloseIdentifier;
+
     /**
      * Table.
      *
@@ -63,7 +65,7 @@ class Update extends Where implements Dml
     /**
      * Pairs to update.
      *
-     * @var string
+     * @var array
      */
     protected $_set   = [];
 
@@ -172,11 +174,11 @@ class Update extends Where implements Dml
             $out .= ' OR ' . $this->_or;
         }
 
-        $out .= ' ' . $this->_table;
+        $out .= ' ' . $this->enclose($this->_table);
         $set  = [];
 
         foreach ($this->_set as $name => $value) {
-            $set[] = $name . ' = ' . $value;
+            $set[] = $this->enclose($name) . ' = ' . $value;
         }
 
         $out .= ' SET ' . implode(', ', $set);

--- a/Test/Unit/Query/EncloseIdentifier.php
+++ b/Test/Unit/Query/EncloseIdentifier.php
@@ -1,0 +1,273 @@
+<?php
+
+/**
+ * Hoa
+ *
+ *
+ * @license
+ *
+ * New BSD License
+ *
+ * Copyright © 2007-2015, Hoa community. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Hoa nor the names of its contributors may be
+ *       used to endorse or promote products derived from this software without
+ *       specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace Hoa\Database\Test\Unit\Query;
+
+use Hoa\Database\Query as CUT;
+use Hoa\Test;
+
+/**
+ * Class \Hoa\Database\Test\Unit\Query\EncloseIdentifier.
+ *
+ * Test suite of EncloseIdentifier feature.
+ *
+ * @copyright  Copyright © 2007-2015 Hoa community
+ * @license    New BSD License
+ */
+class EncloseIdentifier extends Test\Unit\Suite
+{
+    public function case_enabled()
+    {
+        $this
+            ->given($q = new CUT())
+            ->when(
+                $s = $q->select(),
+                $s->enableEncloseIdentifier(),
+                $result = (string) $s->select('a')
+                    ->select('b')
+                    ->from('foo')
+            )
+            ->then
+                ->string($result)
+                    ->isEqualTo('SELECT "a", "b" FROM "foo"');
+    }
+
+    public function case_disabled()
+    {
+        $this
+            ->given($q = new CUT())
+            ->when(
+                $s = $q->select(),
+                $s->enableEncloseIdentifier(false),
+                $result = (string) $s->select('a')
+                    ->select('b')
+                    ->from('foo')
+            )
+            ->then
+                ->string($result)
+                    ->isEqualTo('SELECT a, b FROM foo');
+    }
+
+    public function case_default()
+    {
+        $this
+            ->given($q = new CUT())
+            ->when(
+                $result = (string) $q->select('a')
+                    ->select('b')
+                    ->from('foo')
+            )
+            ->then
+                ->string($result)
+                    ->isEqualTo('SELECT a, b FROM foo');
+    }
+
+    public function case_set_symbol()
+    {
+        $this
+            ->given($q = new CUT())
+            ->when(
+                $s = $q->select(),
+                $s->setEncloseSymbol('[', ']')
+                    ->enableEncloseIdentifier(),
+                $result = (string) $s->select('a')
+                    ->select('b')
+                    ->from('foo')
+            )
+            ->then
+                ->string($result)
+                    ->isEqualTo('SELECT [a], [b] FROM [foo]');
+        }
+
+    public function case_select()
+    {
+        $this
+            ->given($q = new CUT())
+            ->when(
+                $s = $q->select(),
+                $s->enableEncloseIdentifier(),
+                $result = (string) $s->select('a')
+                    ->select('b')
+                    ->from('foo')
+                    ->where('"b" > 10') // manual enclose
+                    ->groupBy('a')
+                    ->having('"a" > 42') // manual enclose
+                    ->orderBy('a')
+                    ->limit('2')
+                    ->offset('1')
+            )
+            ->then
+                ->string($result)
+                    ->isEqualTo(
+                        'SELECT "a", "b" FROM "foo" ' .
+                        'WHERE "b" > 10 ' .
+                        'GROUP BY "a" ' .
+                        'HAVING "a" > 42 ' .
+                        'ORDER BY "a" LIMIT 2 OFFSET 1'
+                    );
+    }
+
+    public function case_select_expr()
+    {
+        $this
+            ->given($q = new CUT())
+            ->when(
+                $s = $q->select(),
+                $s->enableEncloseIdentifier(),
+                $result = (string) $s->select('COUNT("a")') // manual enclose
+                    ->select('b')
+                    ->from('foo')
+                    ->where('"b" > 10') // manual enclose
+                    ->groupBy('a')
+                    ->having('"a" > 42') // manual enclose
+                    ->orderBy('a')
+                    ->limit('2')
+                    ->offset('1')
+            )
+            ->then
+                ->string($result)
+                    ->isEqualTo(
+                        'SELECT COUNT("a"), "b" FROM "foo" ' .
+                        'WHERE "b" > 10 ' .
+                        'GROUP BY "a" ' .
+                        'HAVING "a" > 42 ' .
+                        'ORDER BY "a" LIMIT 2 OFFSET 1'
+                    );
+    }
+
+    public function case_select_alias()
+    {
+        $this
+            ->given($q = new CUT())
+            ->when(
+                $s = $q->select(),
+                $s->enableEncloseIdentifier(),
+                $result = (string) $s->select('"a" AS "bar"') // manual enclose
+                    ->select('b')
+                    ->from('foo')
+                    ->where('"b" > 10') // manual enclose
+                    ->groupBy('a')
+                    ->having('"a" > 42') // manual enclose
+                    ->orderBy('a')
+                    ->limit('2')
+                    ->offset('1')
+            )
+            ->then
+                ->string($result)
+                    ->isEqualTo(
+                        'SELECT "a" AS "bar", "b" FROM "foo" ' .
+                        'WHERE "b" > 10 ' .
+                        'GROUP BY "a" ' .
+                        'HAVING "a" > 42 ' .
+                        'ORDER BY "a" LIMIT 2 OFFSET 1'
+                    );
+    }
+
+    public function case_select_join()
+    {
+        $this
+            ->given($q = new CUT())
+            ->when(
+                $s = $q->select(),
+                $s->enableEncloseIdentifier(),
+                $result = (string) $s->select('a')
+                    ->select('b')
+                    ->from('foo')
+                    ->join('bar')
+                    ->on('"b" = "baz"') // manual enclose
+                    ->where('"b" > 10') // manual enclose
+            )
+            ->then
+                ->string($result)
+                    ->isEqualTo(
+                        'SELECT "a", "b" FROM "foo" ' .
+                        'JOIN "bar" ON "b" = "baz" ' .
+                        'WHERE "b" > 10'
+                    );
+    }
+
+    public function case_insert()
+    {
+        $this
+            ->given($q = new CUT())
+            ->when(
+                $i = $q->insert(),
+                $i->enableEncloseIdentifier(),
+                $result = (string) $i->into('foo')
+                    ->on('a', 'b')
+                    ->values(1, 'bar')
+            )
+            ->then
+                ->string($result)
+                    ->isEqualTo(
+                        'INSERT INTO "foo" ("a", "b") VALUES (1, bar)'
+                    );
+    }
+
+    public function case_update()
+    {
+        $this
+            ->given($q = new CUT())
+            ->when(
+                $u = $q->update(),
+                $u->enableEncloseIdentifier(),
+                $result = (string) $u->table('foo')
+                    ->set('a', 13)
+                    ->set('b', 'bar')
+                    ->where('"b" = 0') // manual enclose
+            )
+            ->then
+                ->string($result)
+                    ->isEqualTo(
+                        'UPDATE "foo" SET "a" = 13, "b" = bar WHERE "b" = 0'
+                    );
+    }
+
+    public function case_delete()
+    {
+        $this
+            ->given($q = new CUT())
+            ->when(
+                $d = $q->delete(),
+                $d->enableEncloseIdentifier(),
+                $result = (string) $d->from('foo')
+                    ->where('"b" = 0') // manual enclose
+            )
+            ->then
+                ->string($result)
+                    ->isEqualTo('DELETE FROM "foo" WHERE "b" = 0');
+    }
+}


### PR DESCRIPTION
Based on [#7 (New feature : enclose names)](https://github.com/hoaproject/Database/issues/7)

This PR will allow use of keywords and resolve some case sensitivity problems for `table`, `column` and `alias` names in the query builder.
The PR don't enclose columns names in `WHERE` and `HAVING` clause.
The feature is disabled by default.

The `Dml` interface have 3 new methods: enable/disable feature and set symbol.
A new `EncolseNames` abstract class is used by `Where` and `Insert` classes to provide the code of this 3 methods.

__________
I did this PR because PostgreSQL need enclosed columns names to be case sensitive.
PS: maybe a method `isEnabled` is missing ?