### PR TITLE
Introduce the late database connection feature.

### DIFF
--- a/Dal.php
+++ b/Dal.php
@@ -81,35 +81,42 @@ class Dal implements Core\Parameter\Parameterizable, Core\Event\Source
      *
      * @var array
      */
-    private static $_instance     = [];
+    private static $_instance        = [];
 
     /**
      * Current singleton ID.
      *
      * @var string
      */
-    private static $_id           = null;
+    private static $_id              = null;
 
     /**
      * Current ID.
      *
      * @var string
      */
-    protected $__id               = null;
+    protected $__id                  = null;
 
     /**
      * The layer instance.
      *
      * @var \Hoa\Database\IDal\Wrapper
      */
-    protected $_layer             = null;
+    protected $_layer                = null;
 
     /**
      * Parameter of \Hoa\Database\Dal.
      *
      * @var \Hoa\Core\Parameter
      */
-    protected static $_parameters = null;
+    protected static $_parameters    = null;
+
+    /**
+     * The layer connection parameter.
+     *
+     * @var array
+     */
+    protected $_connectionParameters = [];
 
 
 
@@ -117,47 +124,18 @@ class Dal implements Core\Parameter\Parameterizable, Core\Event\Source
      * Create a DAL instance, representing a connection to a database.
      * The constructor is private to make a multiton.
      *
-     * @param   string  $dalName          The database abstract layer name.
-     * @param   string  $dsn              The DSN of database.
-     * @param   string  $username         The username to connect to database.
-     * @param   string  $password         The password to connect to database.
-     * @param   array   $driverOptions    The driver options.
+     * @param   array   $connectionParameters    The layer connection parameter.
      * @return  void
-     * @throws  \Hoa\Database\Exception
      */
-    private function __construct(
-        $dalName,
-        $dsn,
-        $username,
-        $password,
-        Array $driverOptions = []
-    ) {
-        // Please see https://bugs.php.net/55154.
-        if (0 !== preg_match('#^sqlite:(.+)$#i', $dsn, $matches)) {
-            $dsn = 'sqlite:' . resolve($matches[1]);
-        }
+    private function __construct(Array $connectionParameters)
+    {
+        $this->_connectionParameters = $connectionParameters;
 
         $id    = $this->__id = self::$_id;
         $event = 'hoa://Event/Database/' . $id;
 
         Core\Event::register($event . ':opened', $this);
         Core\Event::register($event . ':closed', $this);
-
-        $this->setDal(dnew(
-            '\Hoa\Database\Layer\\' . $dalName,
-            [$dsn, $username, $password, $driverOptions]
-        ));
-
-        Core\Event::notify(
-            $event . ':opened',
-            $this,
-            new Core\Event\Bucket([
-                'id'            => $id,
-                'dsn'           => $dsn,
-                'username'      => $username,
-                'driverOptions' => $driverOptions
-            ])
-        );
 
         return;
     }
@@ -244,13 +222,13 @@ class Dal implements Core\Parameter\Parameterizable, Core\Event\Source
             $driverOptions = @$handle['options']  ?: [];
         }
 
-        return self::$_instance[$id] = new self(
+        return self::$_instance[$id] = new self([
             $dalName,
             $dsn,
             $username,
             $password,
             $driverOptions
-        );
+        ]);
     }
 
     /**
@@ -295,6 +273,46 @@ class Dal implements Core\Parameter\Parameterizable, Core\Event\Source
     public function getParameters()
     {
         return self::$_parameters;
+    }
+
+    /**
+     * Open a connection to the database.
+     *
+     * @return  void
+     */
+    private function open()
+    {
+        list(
+            $dalName,
+            $dsn,
+            $username,
+            $password,
+            $driverOptions
+        ) = $this->_connectionParameters;
+
+        // Please see https://bugs.php.net/55154.
+        if (0 !== preg_match('#^sqlite:(.+)$#i', $dsn, $matches)) {
+            $dsn = 'sqlite:' . resolve($matches[1]);
+        }
+
+        $this->setDal(dnew(
+            '\Hoa\Database\Layer\\' . $dalName,
+            [$dsn, $username, $password, $driverOptions]
+        ));
+
+        $id = $this->getId();
+        Core\Event::notify(
+            'hoa://Event/Database/' . $id . ':opened',
+            $this,
+            new Core\Event\Bucket([
+                'id'            => $id,
+                'dsn'           => $dsn,
+                'username'      => $username,
+                'driverOptions' => $driverOptions
+            ])
+        );
+
+        return;
     }
 
     /**
@@ -344,6 +362,10 @@ class Dal implements Core\Parameter\Parameterizable, Core\Event\Source
      */
     protected function getDal()
     {
+        if (null === $this->_layer) {
+            $this->open();
+        }
+
         return $this->_layer;
     }
 

--- a/Dal.php
+++ b/Dal.php
@@ -506,7 +506,7 @@ class Dal implements Core\Parameter\Parameterizable, Core\Event\Source
      */
     public function setAttribute($attribute, $value)
     {
-        return $this->getDal()->setAtribute($attribute, $value);
+        return $this->getDal()->setAttribute($attribute, $value);
     }
 
     /**

--- a/IDal/Wrapper.php
+++ b/IDal/Wrapper.php
@@ -60,7 +60,7 @@ interface Wrapper
         $dsn,
         $username,
         $password,
-        Array $driverOption = []
+        Array $driverOptions = []
     );
 
     /**
@@ -152,7 +152,7 @@ interface Wrapper
      * Return an array of available drivers.
      *
      * @return  array
-     * @throws  \Hoa\Datatase\Exception
+     * @throws  \Hoa\Database\Exception
      */
     public function getAvailableDrivers();
 

--- a/Layer/Pdo/Pdo.php
+++ b/Layer/Pdo/Pdo.php
@@ -275,7 +275,7 @@ class Pdo implements Database\IDal\Wrapper
      * Return an array of available drivers.
      *
      * @return  array
-     * @throws  \Hoa\Datatase\Exception
+     * @throws  \Hoa\Database\Exception
      */
     public function getAvailableDrivers()
     {

--- a/Layer/Pdo/Statement.php
+++ b/Layer/Pdo/Statement.php
@@ -99,7 +99,7 @@ class Statement implements Database\IDal\WrapperStatement
      *
      * @param   array   $bindParameters    Bind parameters values if bindParam
      *                                     is not called.
-     * @return  \Hoa\Database\Pdo\Statement
+     * @return  \Hoa\Database\Layer\Pdo\Statement
      * @throws  \Hoa\Database\Exception
      */
     public function execute(Array $bindParameters = null)

--- a/Query/EncloseIdentifier.php
+++ b/Query/EncloseIdentifier.php
@@ -75,7 +75,7 @@ trait EncloseIdentifier
      *
      * @param   string  $openingSymbol    Opening symbol.
      * @param   string  $closingSymbol    Closing symbol.
-     * @return  \Hoa\Database\Query\EncloseNames
+     * @return  \Hoa\Database\Query\EncloseIdentifier
      */
     public function setEncloseSymbol($openingSymbol, $closingSymbol = null)
     {

--- a/Query/Join.php
+++ b/Query/Join.php
@@ -66,7 +66,7 @@ class Join
      * Constructor.
      *
      * @param   \Hoa\Database\Query\Select  $parent    Parent query.
-     * @param   string                      $from      FROM entry (“friends”).
+     * @param   array                       $from      FROM entry (“friends”).
      * @return  void
      */
     public function __construct(Select $parent, Array &$from)


### PR DESCRIPTION
Thanks to @guiled for the idea, [original PR](https://github.com/hoaproject/Database/pull/19).

The feature allow to instantiate the connection layer, and so open the database connection, at the first call to a wrapped method and not a the `Dal` initialization.