### PR TITLE
Fix SQLite scroll cursors fail

### DIFF
--- a/Layer/Pdo/Pdo.php
+++ b/Layer/Pdo/Pdo.php
@@ -116,7 +116,7 @@ class Pdo implements Database\IDal\Wrapper
     /**
      * Get the connection instance.
      *
-     * @return  PDO
+     * @return  \PDO
      * @throws  \Hoa\Database\Exception
      */
     protected function getConnection()
@@ -194,7 +194,12 @@ class Pdo implements Database\IDal\Wrapper
     public function prepare($statement, array $options = [])
     {
         if (!isset($options[\PDO::ATTR_CURSOR])) {
-            $options[\PDO::ATTR_CURSOR] = \PDO::CURSOR_SCROLL;
+            try {
+                $this->getConnection()->getAttribute(\PDO::ATTR_CURSOR);
+                $options[\PDO::ATTR_CURSOR] = \PDO::CURSOR_SCROLL;
+            } catch (\PDOException $e) {
+                // Cursors isn't supported by the driver, see issue #35.
+            }
         }
 
         $handle = $this->getConnection()->prepare($statement, $options);

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
         "hoa/event"      : "~1.0",
         "hoa/exception"  : "~1.0",
         "hoa/iterator"   : "~2.0",
+        "hoa/protocol"   : "~1.0",
         "hoa/zformat"    : "~1.0",
         "ext-pdo"        : "*"
     },


### PR DESCRIPTION
Fix #35 

Hi,

I don't really like the `getAttribute` call but I don't see any other way to fix that properly.

=====
NB: We need `Hoa\Protocol` since we do a call to `resolve` in `Dal.php`.