### PR TITLE
Add a missing interface on DalStatement.

### DIFF
--- a/DalStatement.php
+++ b/DalStatement.php
@@ -44,7 +44,7 @@ namespace Hoa\Database;
  * @copyright  Copyright © 2007-2016 Hoa community
  * @license    New BSD License
  */
-class DalStatement
+class DalStatement implements IDal\WrapperStatement
 {
     /**
      * Start at the first offset.


### PR DESCRIPTION
The interface is require to allow syntaxe like:
```php
foreach ($stmt as $row) {
    //…
}
```

Otherwise we must specify explicitly `$stmt->getIterator() as …`.